### PR TITLE
Remove redundant span endings

### DIFF
--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -542,7 +542,6 @@ export class AxBaseAI<
       logResponse(res)
     }
 
-    span?.end()
     return res
   }
 
@@ -662,7 +661,6 @@ export class AxBaseAI<
       setResponseAttr(res, span)
     }
 
-    span?.end()
     return res
   }
 


### PR DESCRIPTION
### **User description**
## Summary
- stop calling `span.end()` in `_chat2` and `_embed2`
- rely on `startActiveSpan` callbacks to close spans

## Testing
- `npm test` *(fails: run-s: not found)*


___

### **PR Type**
Enhancement


___

### **Description**
- Remove redundant `span.end()` calls in `_chat2` and `_embed2`

- Rely on `startActiveSpan` callbacks for span closure

- Simplify span management in AI response methods


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.ts</strong><dd><code>Remove redundant span.end() calls from AI methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ax/ai/base.ts

<li>Deleted explicit <code>span.end()</code> calls in <code>_chat2</code> and <code>_embed2</code> methods<br> <li> Now rely on span lifecycle managed by <code>startActiveSpan</code> callbacks<br> <li> Streamlined response handling and span management


</details>


  </td>
  <td><a href="https://github.com/cube-9/ax-example/pull/5/files#diff-801155a65f530af9b7bc6c7e828999cf413623641a160a838f345e9997a7f540">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>